### PR TITLE
fix(extractor): handle Contents as indirect reference to array

### DIFF
--- a/pdf-utils/extractor/src/lib.rs
+++ b/pdf-utils/extractor/src/lib.rs
@@ -216,8 +216,26 @@ fn process_page_dict(
                                 content_streams.push(s.data.clone());
                             }
                         }
+                        PdfObj::Array(arr) => {
+                            for item in arr {
+                                if let PdfObj::Reference(inner_ref) = item {
+                                    if let Some(PdfObj::Stream(s)) = objects.get(inner_ref) {
+                                        if let Some(filter) = s.dict.get("Filter") {
+                                            handle_stream_filters(
+                                                filter,
+                                                &s.data,
+                                                decompress,
+                                                &mut content_streams,
+                                            )?;
+                                        } else {
+                                            content_streams.push(s.data.clone());
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         _ => {
-                            return Err(PdfError::ParseError("Content reference is not a stream"));
+                            return Err(PdfError::ParseError("Content reference is not a stream or array"));
                         }
                     }
                 }


### PR DESCRIPTION
## Description
PDF text extraction fails with error: "text extraction error: ParseError("Content reference is not a stream")"

This occurs on PDFs where `/Contents` is an indirect reference to an array (for example PDFium-generated documents).

The `process_page_dict` function does not handle `/Contents 5 0 R` where object 5 = `[6 0 R 7 0 R]` but it's a valid case in ISO 32000-1 (7.7.3.3) and used by PDFium (Chrome's PDF engine)

## Changes
- Added `PdfObj::Array` handling when dereferencing a `/Contents` reference, iterating through and extracting each stream.

## Testing
- `cargo test -p extractor` passes
- Tested with PDFium-generated PDF that previously failed